### PR TITLE
Update errata.md

### DIFF
--- a/_pages/book/errata.md
+++ b/_pages/book/errata.md
@@ -16,7 +16,7 @@ header:
 
 Page 42. In Figure 3.4 the annotation “mention reviews” should be “and mentions language” like in Figure 1.10.
 
-Page 44. "ellipsis" should have been "ellipses".
+Page 44. In the sentence starting “Hence, the ellipsis contains…” the word “ellipsis” should be “ellipse.” (Thanks to [Karel Vervaeke](https://github.com/karel1980))
 
 #### Chapter 5, “Modeling Tools”
 

--- a/_pages/book/errata.md
+++ b/_pages/book/errata.md
@@ -16,6 +16,8 @@ header:
 
 Page 42. In Figure 3.4 the annotation “mention reviews” should be “and mentions language” like in Figure 1.10.
 
+Page 44. "ellipsis" should have been "ellipses".
+
 #### Chapter 5, “Modeling Tools”
 
 Page 59. The first sentences in the bullet list should be set in bold like on the page before. That is “Sticky notes just for work objects:” and “Sticky notes for actors, work objects, and sequence numbers:”.


### PR DESCRIPTION
Ellipsis is what's known as dot-dot-dot. The plural of ellipse is ellipses. The correct spelling has been used earlier in the same paragraph. (Incidently, the plural of ellipsis is also ellipses, but that's besides the point).