### PR TITLE
Fix links in quick-start-guide.md

### DIFF
--- a/_pages/quick-start-guide.md
+++ b/_pages/quick-start-guide.md
@@ -71,7 +71,7 @@ Once the story is finished, the moderator checks if all participants agree upon 
 
 > Modeling is a thinking tool.The act of modeling is more important than the actual model.
 
-Do not think of Domain Stories as documentation. Use them to dive into <a href="#dst-ddd">Domain Driven Design</a>, or <a href="#dst-requirements">to uncover requirements</a> for software development. Inviting the right people to the workshops is important because the primary goal is to learn and communicate. A picture of a Domain Story serves as an aid to memory for those present at the workshop, but it is not a replacement for participating.
+Do not think of Domain Stories as documentation. Use them to dive into [Domain Driven Design](./domain-driven-design.md), or [to uncover requirements](./requirements.md) for software development. Inviting the right people to the workshops is important because the primary goal is to learn and communicate. A picture of a Domain Story serves as an aid to memory for those present at the workshop, but it is not a replacement for participating.
 
 ## Tools
 


### PR DESCRIPTION
fix links by switching to Markdown relative file references